### PR TITLE
🦑 Prepare v0.11.8 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ debug: true
 logger:
     format: console
     level: info
+    trace_level: fatal
     no_disclaimer: false
     color: true
     full_caller: true
@@ -126,12 +127,14 @@ LOGGER_COLOR=true
 LOGGER_FULL_CALLER=true
 LOGGER_FORMAT=console
 LOGGER_LEVEL=info
+LOGGER_TRACE_LEVEL=fatal
 LOGGER_SAMPLING_INITIAL=100
 LOGGER_SAMPLING_THEREAFTER=100
 ```
 
 - `debug` - with this option you can enable `zap.DevelopmentConfig()`
 - `logger.no_disclaimer` - with this option, you can disable `app_name` and `app_version` for any reason (not recommended in production)
+- `logger.trace_level` - configures the Logger to record a stack trace for all messages at or above a given level
 - `logger.color` - serializes a Level to an all-caps string and adds color
 - `logger.full_caller` - serializes a caller in /full/path/to/package/file:line format
 - `logger.sampling.initial` and `logger.sampling.thereafter` to setup [logger sampling](https://godoc.org/go.uber.org/zap#SamplingConfig). SamplingConfig sets a sampling strategy for the logger. Sampling caps the global CPU and I/O load that logging puts on your process while attempting to preserve a representative subset of your logs. Values configured here are per-second. See [zapcore.NewSampler](https://godoc.org/go.uber.org/zap/zapcore#NewSampler) for details.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/common v0.3.0 // indirect
 	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967 // indirect

--- a/logger/std_test.go
+++ b/logger/std_test.go
@@ -5,39 +5,36 @@ import (
 	"testing"
 
 	"bou.ke/monkey"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
 func TestStdLogger(t *testing.T) {
-	Convey("StdLogger test suite", t, func(c C) {
-		std := NewStdLogger(zap.L())
+	std := NewStdLogger(zap.L())
 
-		c.Convey("Not fatal calls should not panic", func(c C) {
-			c.Convey("print", func(c C) {
-				c.So(func() { std.Print("panic no") }, ShouldNotPanic)
-			})
-
-			c.Convey("printf", func(c C) {
-				c.So(func() { std.Printf("panic %s", "no") }, ShouldNotPanic)
-			})
-
+	t.Run("not fatal calls should not panic", func(t *testing.T) {
+		t.Run("print", func(t *testing.T) {
+			require.NotPanics(t, func() { std.Print("panic no") })
 		})
 
-		c.Convey("Fatal(f) should call os.Exit with 1 code", func(c C) {
-			var exitCode int
-			monkey.Patch(os.Exit, func(code int) { exitCode = code })
-			defer monkey.Unpatch(os.Exit)
+		t.Run("printf", func(t *testing.T) {
+			require.NotPanics(t, func() { std.Printf("panic no") })
+		})
+	})
 
-			c.Convey("Fatal", func(c C) {
-				c.So(func() { std.Fatal("panic no") }, ShouldNotPanic)
-				c.So(exitCode, ShouldEqual, 1)
-			})
+	t.Run("Fatal(f) should call os.Exit with 1 code", func(t *testing.T) {
+		var exitCode int
+		monkey.Patch(os.Exit, func(code int) { exitCode = code })
+		defer monkey.Unpatch(os.Exit)
 
-			c.Convey("Fatalf", func(c C) {
-				c.So(func() { std.Fatalf("panic %s", "no") }, ShouldNotPanic)
-				c.So(exitCode, ShouldEqual, 1)
-			})
+		t.Run("fatal", func(t *testing.T) {
+			require.NotPanics(t, func() { std.Fatal("panic no") })
+			require.Equal(t, 1, exitCode)
+		})
+
+		t.Run("fatalf", func(t *testing.T) {
+			require.NotPanics(t, func() { std.Fatalf("panic no") })
+			require.Equal(t, 1, exitCode)
 		})
 	})
 }

--- a/logger/zap.go
+++ b/logger/zap.go
@@ -56,6 +56,7 @@ func NewLoggerConfig(v *viper.Viper) *Config {
 	return cfg
 }
 
+// SafeLevel returns valid logger level or default
 func SafeLevel(lvl string, defaultLvl zapcore.Level) zap.AtomicLevel {
 	switch strings.ToLower(lvl) {
 	case "debug":

--- a/logger/zap_test.go
+++ b/logger/zap_test.go
@@ -1,133 +1,138 @@
 package logger
 
 import (
-	"errors"
+	"strings"
 	"testing"
 
 	"bou.ke/monkey"
 	"github.com/im-kulikov/helium/settings"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/pkg/errors"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 func TestZapLogger(t *testing.T) {
-	Convey("ZapLogger test suite", t, func(c C) {
+	t.Run("check logger config", func(t *testing.T) {
 		v := viper.New()
 
-		c.Convey("check logger config", func(c C) {
-			c.Convey("empty config", func(c C) {
-				cfg := NewLoggerConfig(v)
-				c.So(cfg.Level, ShouldBeZeroValue)
-				c.So(cfg.Format, ShouldBeZeroValue)
-				c.So(cfg.Debug, ShouldBeZeroValue)
-				c.So(cfg.NoDisclaimer, ShouldBeZeroValue)
-			})
-
-			c.Convey("setup config", func(c C) {
-				v.SetDefault("debug", true)
-				v.SetDefault("logger.no_disclaimer", true)
-				v.SetDefault("logger.level", "info")
-				v.SetDefault("logger.format", "console")
-				v.SetDefault("logger.color", true)
-				v.SetDefault("logger.full_caller", true)
-				v.SetDefault("logger.sampling.initial", 100)
-				v.SetDefault("logger.sampling.thereafter", 100)
-
-				cfg := NewLoggerConfig(v)
-				c.So(cfg.Level, ShouldEqual, "info")
-				c.So(cfg.Format, ShouldEqual, "console")
-
-				c.So(cfg.Sampling, ShouldNotBeNil)
-				c.So(cfg.Sampling.Initial, ShouldEqual, 100)
-				c.So(cfg.Sampling.Thereafter, ShouldEqual, 100)
-
-				_, err := NewLogger(cfg, &settings.Core{})
-				c.So(err, ShouldBeNil)
-			})
-
-			c.Convey("config safely", func(c C) {
-				levels := []string{
-					"bad",
-					"debug", "DEBUG",
-					"info", "INFO",
-					"warn", "WARN",
-					"error", "ERROR",
-					"panic", "PANIC",
-					"fatal", "FATAL",
-				}
-
-				formats := []string{"bad", "console", "json"}
-
-				for _, item := range levels {
-					v.SetDefault("logger.level", item)
-					v.SetDefault("logger.format", "bad")
-					cfg := NewLoggerConfig(v)
-					if item == "bad" {
-						item = "info"
-					}
-
-					c.So(cfg.SafeLevel(), ShouldEqual, item)
-					c.So(cfg.SafeFormat(), ShouldEqual, "json")
-				}
-
-				for _, item := range formats {
-					v.SetDefault("logger.level", "bad")
-					v.SetDefault("logger.format", item)
-					cfg := NewLoggerConfig(v)
-					if item == "bad" {
-						item = "json"
-					}
-
-					c.So(cfg.SafeLevel(), ShouldEqual, "info")
-					c.So(cfg.SafeFormat(), ShouldEqual, item)
-				}
-			})
+		t.Run("empty config", func(t *testing.T) {
+			cfg := NewLoggerConfig(v)
+			require.Empty(t, cfg.Level)
+			require.Empty(t, cfg.Format)
+			require.Empty(t, cfg.Debug)
+			require.Empty(t, cfg.NoDisclaimer)
 		})
 
-		c.Convey("check logger", func(c C) {
-			c.Convey("all ok", func(c C) {
-				v.SetDefault("debug", true)
-				v.SetDefault("logger.no_disclaimer", true)
+		t.Run("setup config", func(t *testing.T) {
+			v.SetDefault("debug", true)
+			v.SetDefault("logger.no_disclaimer", true)
+			v.SetDefault("logger.level", "info")
+			v.SetDefault("logger.format", "console")
+			v.SetDefault("logger.color", true)
+			v.SetDefault("logger.full_caller", true)
+			v.SetDefault("logger.sampling.initial", 100)
+			v.SetDefault("logger.sampling.thereafter", 100)
 
+			cfg := NewLoggerConfig(v)
+			require.Equal(t, "info", cfg.Level)
+			require.Equal(t, "console", cfg.Format)
+
+			require.NotNil(t, cfg.Sampling)
+			require.Equal(t, 100, cfg.Sampling.Initial)
+			require.Equal(t, 100, cfg.Sampling.Thereafter)
+
+			_, err := NewLogger(cfg, &settings.Core{})
+			require.NoError(t, err)
+		})
+
+		t.Run("config safely", func(t *testing.T) {
+			levels := []string{
+				"bad",
+				"debug", "DEBUG",
+				"info", "INFO",
+				"warn", "WARN",
+				"error", "ERROR",
+				"panic", "PANIC",
+				"fatal", "FATAL",
+			}
+
+			formats := []string{"bad", "console", "json"}
+
+			for _, item := range levels {
+				v.SetDefault("logger.level", item)
+				v.SetDefault("logger.format", "bad")
 				cfg := NewLoggerConfig(v)
-				log, err := NewLogger(cfg, &settings.Core{})
-				c.So(err, ShouldBeNil)
-				c.So(log, ShouldNotBeNil)
-			})
+				if item == "bad" {
+					item = "info"
+				}
 
-			c.Convey("should fail on level", func(c C) {
+				require.Equal(t, strings.ToLower(item), SafeLevel(item, zapcore.InfoLevel).String())
+				require.Equal(t, "json", cfg.SafeFormat())
+			}
+
+			for _, item := range formats {
 				v.SetDefault("logger.level", "bad")
+				v.SetDefault("logger.format", item)
 				cfg := NewLoggerConfig(v)
-				log, err := NewLogger(cfg, &settings.Core{})
-				c.So(err, ShouldBeError)
-				c.So(log, ShouldBeNil)
+				if item == "bad" {
+					item = "json"
+				}
+
+				require.Equal(t, "info", SafeLevel(item, zapcore.InfoLevel).String())
+				require.Equal(t, item, cfg.SafeFormat())
+			}
+		})
+	})
+
+	t.Run("check logger", func(t *testing.T) {
+		t.Run("all ok", func(t *testing.T) {
+			v := viper.New()
+			v.SetDefault("debug", true)
+			v.SetDefault("logger.no_disclaimer", true)
+
+			cfg := NewLoggerConfig(v)
+			log, err := NewLogger(cfg, &settings.Core{})
+			require.NoError(t, err)
+			require.NotNil(t, log)
+		})
+
+		t.Run("should not fail on bad level", func(t *testing.T) {
+			v := viper.New()
+			v.SetDefault("logger.level", "bad")
+
+			cfg := NewLoggerConfig(v)
+			log, err := NewLogger(cfg, &settings.Core{})
+			require.NoError(t, err)
+			require.NotNil(t, log)
+		})
+
+		t.Run("should fail on stdout", func(t *testing.T) {
+			v := viper.New()
+
+			monkey.Patch(zap.Open, func(paths ...string) (zapcore.WriteSyncer, func(), error) {
+				return nil, nil, errors.New("test")
 			})
 
-			c.Convey("should fail on stdout", func(c C) {
-				monkey.Patch(zap.Open, func(paths ...string) (zapcore.WriteSyncer, func(), error) {
-					return nil, nil, errors.New("test")
-				})
+			defer monkey.Unpatch(zap.Open)
 
-				defer monkey.Unpatch(zap.Open)
+			v.SetDefault("logger.level", "info")
+			cfg := NewLoggerConfig(v)
+			log, err := NewLogger(cfg, &settings.Core{})
+			require.Error(t, err)
+			require.Nil(t, log)
+		})
 
-				v.SetDefault("logger.level", "info")
-				cfg := NewLoggerConfig(v)
-				log, err := NewLogger(cfg, &settings.Core{})
-				c.So(err, ShouldBeError)
-				c.So(log, ShouldBeNil)
-			})
-
-			c.Convey("check sugared", func(c C) {
-				v.SetDefault("logger.level", "info")
-				cfg := NewLoggerConfig(v)
-				log, err := NewLogger(cfg, &settings.Core{})
-				c.So(err, ShouldBeNil)
-				c.So(log, ShouldNotBeNil)
-				sug := NewSugaredLogger(log)
-				c.So(sug, ShouldNotBeNil)
-			})
+		t.Run("check sugared", func(t *testing.T) {
+			v := viper.New()
+			v.SetDefault("logger.level", "info")
+			cfg := NewLoggerConfig(v)
+			log, err := NewLogger(cfg, &settings.Core{})
+			require.NoError(t, err)
+			require.NotNil(t, log)
+			sug := NewSugaredLogger(log)
+			require.NotNil(t, sug)
 		})
 	})
 }


### PR DESCRIPTION
- `logger.trace_level`
- simplify `NewLogger`
- replace go-convey with `testify/require`