### PR TITLE
Updates for go 1.16

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.13.x', '1.14.x', '1.15.x']
+        go: [ '1.14.x', '1.15.x', '1.16.x' ]
     steps:
 
     - name: Setup go

--- a/go.sum
+++ b/go.sum
@@ -353,6 +353,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -553,7 +554,7 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.34.0 h1:raiipEjMOIC/TO2AvyTxP25XFdLxNIBwzDh3FM3XztI=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
-google.golang.org/grpc v1.34.1/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
+google.golang.org/grpc v1.35.0 h1:TwIQcH3es+MojMVojxxfQ3l3OF2KzlRxML2xZq0kRo8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/grace/grace.go
+++ b/grace/grace.go
@@ -1,30 +1,10 @@
 package grace
 
 import (
-	"context"
-	"os"
-	"os/signal"
-	"syscall"
-
 	"github.com/im-kulikov/helium/module"
-	"go.uber.org/zap"
 )
 
 // Module graceful context
 var Module = module.Module{
 	{Constructor: NewGracefulContext},
-}
-
-// NewGracefulContext returns graceful context
-func NewGracefulContext(l *zap.Logger) context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
-		sig := <-ch
-		l.Info("received signal",
-			zap.String("signal", sig.String()))
-		cancel()
-	}()
-	return ctx
 }

--- a/grace/grace_go1.15.go
+++ b/grace/grace_go1.15.go
@@ -1,0 +1,26 @@
+// +build !go1.16
+
+package grace
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"go.uber.org/zap"
+)
+
+// NewGracefulContext returns graceful context
+func NewGracefulContext(l *zap.Logger) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+		sig := <-ch
+		l.Info("received stop signal",
+			zap.String("signal", sig.String()))
+		cancel()
+	}()
+	return ctx
+}

--- a/grace/grace_go1.16.go
+++ b/grace/grace_go1.16.go
@@ -1,0 +1,24 @@
+// +build go1.16
+
+package grace
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"go.uber.org/zap"
+)
+
+// NewGracefulContext returns graceful context
+func NewGracefulContext(l *zap.Logger) context.Context {
+	ctx, _ := signal.NotifyContext(context.Background(),
+		syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+
+	go func() {
+		<-ctx.Done()
+		l.Info("receive stop signal")
+	}()
+
+	return ctx
+}

--- a/grace/grace_test.go
+++ b/grace/grace_test.go
@@ -7,23 +7,21 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestGrace(t *testing.T) {
-	var (
-		log = zap.L()
-		ctx = NewGracefulContext(log)
-	)
-
-	// waiting to run the goroutine and channel of signals
-	<-time.Tick(100 * time.Millisecond)
-
 	signals := []syscall.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP}
 	for i := range signals {
 		sig := signals[i]
 		t.Run(fmt.Sprintf("should cancel context on %s signal", sig), func(t *testing.T) {
 			is := assert.New(t)
+
+			log := zaptest.NewLogger(t)
+			ctx := NewGracefulContext(log)
+
+			// waiting to run the goroutine and channel of signals
+			<-time.After(time.Millisecond)
 
 			err := syscall.Kill(syscall.Getpid(), sig)
 			is.NoError(err)


### PR DESCRIPTION
- Removed go1.13 and added go1.16
- Update dependencies
  - github.com/stretchr/testify v1.7.0
  - google.golang.org/grpc v1.35.0
- Migrate to go1.16
  - fixes for tests
  - graceful for go1.15 and below
  - graceful for go1.16 and above